### PR TITLE
301 Moved permenantly for www.codeship.io; the api works for codeship.com

### DIFF
--- a/lib/codeship/request.rb
+++ b/lib/codeship/request.rb
@@ -4,7 +4,7 @@ module Codeship
   module Request
 
     def http_request
-      http = Net::HTTP.new "www.codeship.io", 443
+      http = Net::HTTP.new "codeship.com", 443
       http.use_ssl = true
       http
     end

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_branchnotfound.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_branchnotfound.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/branchnotfound/status
+    uri: https://codeship.com/projects/branchnotfound/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_error.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/error/status
+    uri: https://codeship.com/projects/error/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_ignored.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_ignored.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/ignored/status
+    uri: https://codeship.com/projects/ignored/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_projectnotfound.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_projectnotfound.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/projectnotfound/status
+    uri: https://codeship.com/projects/projectnotfound/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_success.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/success/status
+    uri: https://codeship.com/projects/success/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_testing.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_testing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/testing/status
+    uri: https://codeship.com/projects/testing/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_waiting.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status/should_parse_waiting.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/waiting/status
+    uri: https://codeship.com/projects/waiting/status
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_branchnotfound.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_branchnotfound.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/branchnotfound/status?branch=master
+    uri: https://codeship.com/projects/branchnotfound/status?branch=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_error.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/error/status?branch=master
+    uri: https://codeship.com/projects/error/status?branch=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_ignored.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_ignored.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/ignored/status?branch=master
+    uri: https://codeship.com/projects/ignored/status?branch=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_projectnotfound.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_projectnotfound.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/projectnotfound/status?branch=master
+    uri: https://codeship.com/projects/projectnotfound/status?branch=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_success.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_success.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/success/status?branch=master
+    uri: https://codeship.com/projects/success/status?branch=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_testing.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_testing.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/testing/status?branch=master
+    uri: https://codeship.com/projects/testing/status?branch=master
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_waiting.yml
+++ b/spec/fixtures/cassettes/Codeship_Status/parsing_the_project_status_on_a_certain_branch/should_parse_waiting.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: head
-    uri: https://www.codeship.io/projects/waiting/status?branch=master
+    uri: https://codeship.com/projects/waiting/status?branch=master
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
301 Moved permenantly for www.codeship.io; the api works for codeship.com but fails for:
www.codeship.io, codeship.io, www.codeship.com both for http & https.

The api succeeds for https://codeship.com

Have updated VCR cassettes to reflect new domain. 
