### PR TITLE
Bug/status image format

### DIFF
--- a/lib/codeship/status.rb
+++ b/lib/codeship/status.rb
@@ -14,7 +14,7 @@ module Codeship
     end
 
     def status
-      image.scan(/status_(.*).png/).flatten.first.to_sym
+      image.scan(/status_(.*).(png|gif)/).flatten.first.to_sym
     end
 
     private

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -2,28 +2,59 @@ require 'spec_helper'
 
 RSpec.describe Codeship::Status do
   context 'parsing the project status' do
-    Codeship::Status::STATES.each do |state|
-      it "should parse #{state}" do
+    context 'of a project with completed build' do
+      Codeship::Status::STATES.each do |state|
+        it "should parse #{state}" do
 
-        stub_request(:head, "https://codeship.com/projects/#{state}/status").
-                 with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
-                 to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
+          stub_request(:head, "https://codeship.com/projects/#{state}/status").
+                   with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+                   to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
 
-        project_status = Codeship::Status.new(state)
-        expect(project_status.status).to eq(state)
+          project_status = Codeship::Status.new(state)
+          expect(project_status.status).to eq(state)
+        end
+      end
+    end
+
+    context 'of a project with active build' do
+      Codeship::Status::STATES.each do |state|
+        it "should parse #{state}" do
+
+          stub_request(:head, "https://codeship.com/projects/#{state}/status").
+                   with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+                   to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.gif\""})
+
+          project_status = Codeship::Status.new(state)
+          expect(project_status.status).to eq(state)
+        end
       end
     end
   end
 
   context 'parsing the project status on a certain branch' do
-    Codeship::Status::STATES.each do |state|
-      it "should parse #{state}" do
-        stub_request(:head, "https://codeship.com/projects/#{state}/status?branch=master").
-                 with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
-                 to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
+    context 'of a project with completed build' do
+      Codeship::Status::STATES.each do |state|
+        it "should parse #{state}" do
+          stub_request(:head, "https://codeship.com/projects/#{state}/status?branch=master").
+                   with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+                   to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
 
-        project_status = Codeship::Status.new(state, branch: 'master')
-        expect(project_status.status).to eq(state)
+          project_status = Codeship::Status.new(state, branch: 'master')
+          expect(project_status.status).to eq(state)
+        end
+      end
+    end
+
+    context 'of a project with active build' do
+      Codeship::Status::STATES.each do |state|
+        it "should parse #{state}" do
+          stub_request(:head, "https://codeship.com/projects/#{state}/status?branch=master").
+                   with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+                   to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.gif\""})
+
+          project_status = Codeship::Status.new(state, branch: 'master')
+          expect(project_status.status).to eq(state)
+        end
       end
     end
   end


### PR DESCRIPTION
Project status calls currently fail for builds in :testing, :waiting, :stopped states because badges for these states are now .gifs rather than .pngs:
```
NoMethodError: undefined method `to_sym' for nil:NilClass
	from .../codeship-ruby/lib/codeship/status.rb:17:in `status'
```
Fixed with simple regex update and added tests stubbed with .gif responses for all build states in case more badges change in the future.