### PR TITLE
Update codeship base URL

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,11 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
 
 desc "Open an irb session preloaded with this library"
 task :console do
   sh "irb -rubygems -I lib -r codeship.rb"
 end
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/lib/codeship/request.rb
+++ b/lib/codeship/request.rb
@@ -4,7 +4,7 @@ module Codeship
   module Request
 
     def http_request
-      http = Net::HTTP.new "codeship.com", 443
+      http = Net::HTTP.new "app.codeship.com", 443
       http.use_ssl = true
       http
     end

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Codeship::Status do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
 
-          stub_request(:head, "https://codeship.com/projects/#{state}/status").
+          stub_request(:head, "https://app.codeship.com/projects/#{state}/status").
                    with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
                    to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
 
@@ -20,7 +20,7 @@ RSpec.describe Codeship::Status do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
 
-          stub_request(:head, "https://codeship.com/projects/#{state}/status").
+          stub_request(:head, "https://app.codeship.com/projects/#{state}/status").
                    with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
                    to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.gif\""})
 
@@ -35,7 +35,7 @@ RSpec.describe Codeship::Status do
     context 'of a project with completed build' do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
-          stub_request(:head, "https://codeship.com/projects/#{state}/status?branch=master").
+          stub_request(:head, "https://app.codeship.com/projects/#{state}/status?branch=master").
                    with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
                    to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
 
@@ -48,7 +48,7 @@ RSpec.describe Codeship::Status do
     context 'of a project with active build' do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
-          stub_request(:head, "https://codeship.com/projects/#{state}/status?branch=master").
+          stub_request(:head, "https://app.codeship.com/projects/#{state}/status?branch=master").
                    with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
                    to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.gif\""})
 


### PR DESCRIPTION
Regular API requests still work fine, status requests we're breaking on, as https://codeship.com/projects/:uuid/status redirects to https://app.codeship.com/projects/:uuid/status.

So the response to codeship.com/... is a 301 without the needed `Content-Disposition` header.

This PR just adjusts the base URL used to make all requests to Codeship.