### PR TITLE
Support SVG status image

### DIFF
--- a/lib/codeship/status.rb
+++ b/lib/codeship/status.rb
@@ -14,7 +14,7 @@ module Codeship
     end
 
     def status
-      image.scan(/status_(.*).(png|gif)/).flatten.first.to_sym
+      image.scan(/status_(.*).(png|gif|svg)/).flatten.first.to_sym
     end
 
     private

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 RSpec.describe Codeship::Status do
   context 'parsing the project status' do
-    context 'of a project with completed build' do
+    context 'which returns a png' do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
 
@@ -16,7 +16,7 @@ RSpec.describe Codeship::Status do
       end
     end
 
-    context 'of a project with active build' do
+    context 'which returns a gif' do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
 
@@ -29,12 +29,27 @@ RSpec.describe Codeship::Status do
         end
       end
     end
+
+    context 'which returns a svg' do
+      Codeship::Status::STATES.each do |state|
+        it "should parse #{state}" do
+
+          stub_request(:head, "https://app.codeship.com/projects/#{state}/status").
+                   with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+                   to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.svg\""})
+
+          project_status = Codeship::Status.new(state)
+          expect(project_status.status).to eq(state)
+        end
+      end
+    end
   end
 
   context 'parsing the project status on a certain branch' do
-    context 'of a project with completed build' do
+    context 'which returns a png' do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
+
           stub_request(:head, "https://app.codeship.com/projects/#{state}/status?branch=master").
                    with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
                    to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.png\""})
@@ -45,12 +60,27 @@ RSpec.describe Codeship::Status do
       end
     end
 
-    context 'of a project with active build' do
+    context 'which returns a gif' do
       Codeship::Status::STATES.each do |state|
         it "should parse #{state}" do
+
           stub_request(:head, "https://app.codeship.com/projects/#{state}/status?branch=master").
                    with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
                    to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.gif\""})
+
+          project_status = Codeship::Status.new(state, branch: 'master')
+          expect(project_status.status).to eq(state)
+        end
+      end
+    end
+
+    context 'which returns a svg' do
+      Codeship::Status::STATES.each do |state|
+        it "should parse #{state}" do
+
+          stub_request(:head, "https://app.codeship.com/projects/#{state}/status?branch=master").
+                   with(headers: {'Accept'=>'*/*', 'User-Agent'=>'Ruby'}).
+                   to_return(status: 200, body: "", headers: {'Content-Disposition' => "inline; filename=\"status_#{state}.svg\""})
 
           project_status = Codeship::Status.new(state, branch: 'master')
           expect(project_status.status).to eq(state)


### PR DESCRIPTION
Getting a branch status currently crashes because Codeship images are now SVGs.