### PR TITLE
README: Add warning on deprecated API v1 only support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Codeship
 
+**⚠️⚠️⚠️** This gem only supports v1 of Codeship's API which is [deprecated as of July 1st 2018](https://apidocs.codeship.com/v1/introduction/limitations). **⚠️⚠️⚠️**
+
 Interact with Codeship.
 
 ![Codeship Status for codeship/codeship-ruby](https://app.codeship.com/projects/e8bf3890-ee53-0130-957a-52ea4b2c7608/status)


### PR DESCRIPTION
Since API v1 is deprecated now, it would be nice to let users see that this gem (currently) does not support the new API.